### PR TITLE
feat(ios): use an injected simulator camera when one is present

### DIFF
--- a/ios/multicamera/Sources/multicamera/CameraHandle.swift
+++ b/ios/multicamera/Sources/multicamera/CameraHandle.swift
@@ -154,10 +154,6 @@ class CameraHandle: NSObject {
     if device != nil { return }
 
     #if targetEnvironment(simulator)
-      // The simulator has no camera hardware, but a camera-injection tool
-      // (sim-cli/Iris, SimulatorCamera) can publish one that AVFoundation
-      // discovers normally. Only fall back to the placeholder frame when
-      // discovery really comes up empty, so an injected feed reaches the app.
       if selectDevice() == nil {
         showSimulatorWarning()
         return

--- a/ios/multicamera/Sources/multicamera/CameraHandle.swift
+++ b/ios/multicamera/Sources/multicamera/CameraHandle.swift
@@ -154,8 +154,14 @@ class CameraHandle: NSObject {
     if device != nil { return }
 
     #if targetEnvironment(simulator)
-      showSimulatorWarning()
-      return
+      // The simulator has no camera hardware, but a camera-injection tool
+      // (sim-cli/Iris, SimulatorCamera) can publish one that AVFoundation
+      // discovers normally. Only fall back to the placeholder frame when
+      // discovery really comes up empty, so an injected feed reaches the app.
+      if selectDevice() == nil {
+        showSimulatorWarning()
+        return
+      }
     #endif
 
     Self.session.beginConfiguration()


### PR DESCRIPTION
## What

`CameraHandle.createDevice()` returns before touching AVFoundation on the simulator, so the placeholder frame from v1.10.0 is all an app can get there:

```swift
#if targetEnvironment(simulator)
  showSimulatorWarning()
  return
#endif
```

That's the right default — the Simulator genuinely has no camera hardware — but it also makes the plugin blind to **camera-injection tools**, which publish a virtual device that `AVCaptureDevice.DiscoverySession` finds through the normal API. This tries discovery first and falls back to the placeholder only when it really comes up empty:

```swift
#if targetEnvironment(simulator)
  if selectDevice() == nil {
    showSimulatorWarning()
    return
  }
#endif
```

Eight lines, no behaviour change when nothing is injected: `selectDevice()` returns nil, the placeholder renders exactly as it does today.

## Why it matters for us

We run the Sign In App kiosk in the simulator for day-to-day dev. The placeholder is a real improvement for photo capture, but QR scanning is a dead end there — the scanner renders and simply never fires, since nothing feeds `AVCaptureMetadataOutput`. With an injector supplying frames *and* metadata objects, scanning works in the simulator, which removes a whole class of "you need a physical iPad for this" from the loop.

## Verification

Against [sim-cli](https://github.com/annurdien/sim-cli)'s Iris injector (I have [a PR open there](https://github.com/annurdien/sim-cli/pull/19) adding the `AVCaptureMetadataOutput` half), iPad Pro simulator, Xcode 26.6 / macOS 26.5:

- Live MacBook webcam rendering in the kiosk's camera preview.
- A QR code held up to the Mac camera arriving in `onBarcodesScanned` with the decoded payload.
- With the injector stopped: unchanged placeholder behaviour.

One thing worth knowing if you pick this up: **Vision does not work in the Simulator at all** — every `VNImageRequestHandler` fails with *"Could not create inference context"*, faces included. So the metadata side of an injector has to use `CIDetector`, which covers QR and faces only. Nothing for this repo to change, but it's why the injected-simulator story can't cover the full symbology set.